### PR TITLE
Update coordinate & bump deps & release 0.3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,8 @@ language: clojure
 lein: 2.9.1
 dist: trusty
 script: lein midje
+
+jdk:
+  - oraclejdk8
+  - openjdk11
+  - openjdk13

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: clojure
-lein: lein2
-script: lein2 midje
+lein: 2.9.1
+dist: trusty
+script: lein midje

--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
-> This project has two homes.
-> It is ok to work in github, still, for a better decentralized web
-> please consider contributing (issues, PR, etc...) throught:
->
-> https://gitlab.esy.fun/yogsototh/clj-jwt
-
----
-
-
 # clj-jwt
 
-[![clj-jwt](https://img.shields.io/clojars/v/yogsototh/clj-jwt.svg)](https://clojars.org/yogsototh/clj-jwt)
+[![clj-jwt](https://img.shields.io/clojars/v/threatgrid/clj-jwt.svg)](https://clojars.org/threatgrid/clj-jwt)
 [![Dependency Status](https://www.versioneye.com/user/projects/53462a37e97a46e756000308/badge.png)](https://www.versioneye.com/user/projects/53462a37e97a46e756000308)
-[![Build Status](https://travis-ci.org/yogsototh/clj-jwt.png?branch=master)](https://travis-ci.org/liquidz/clj-jwt)
+[![Build Status](https://travis-ci.org/threatgrid/clj-jwt.png?branch=master)](https://travis-ci.org/threatgrid/clj-jwt)
 
 A Clojure library for JSON Web Token(JWT) [draft-ietf-oauth-json-web-token-19](http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-19)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-jwt "0.3.1-SNAPSHOT"
+(defproject threatgrid/clj-jwt "0.3.1"
   :description  "Clojure library for JSON Web Token(JWT)"
   :url          "https://github.com/threatgrid/clj-jwt"
   :pedantic?    :abort

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,14 @@
-(defproject yogsototh/clj-jwt "0.3.1-SNAPSHOT"
+(defproject threatgrid/clj-jwt "0.3.1-SNAPSHOT"
   :description  "Clojure library for JSON Web Token(JWT)"
-  :url          "https://github.com/yogsototh/clj-jwt"
+  :url          "https://github.com/threatgrid/clj-jwt"
+  :pedantic?    :abort
   :license      {:name "Eclipse Public License"
                  :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/data.json "0.2.6"]
-                 [org.clojure/data.codec "0.1.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/data.json "1.0.0"]
+                 [org.clojure/data.codec "0.1.1"]
                  [org.bouncycastle/bcpkix-jdk15on "1.52"]
                  [crypto-equality "1.0.0"]
-                 [clj-time "0.11.0"]]
-  :profiles {:dev {:dependencies [[midje "1.7.0"  :exclusions [org.clojure/clojure]]]}}
-  :plugins  [[lein-midje "3.1.3"]])
+                 [clj-time "0.15.2"]]
+  :profiles {:dev {:dependencies [[midje "1.9.9"]]}}
+  :plugins  [[lein-midje "3.2.1"]])


### PR DESCRIPTION
Tested in:
- https://github.com/threatgrid/ring-jwt-middleware/pull/21
- https://github.com/threatgrid/iroh/pull/3355
- https://github.com/threatgrid/ctia/pull/885

After merge:
1. Release and tag 0.3.1
2. Bump dev snapshot in new PR