### PR TITLE
fix init issue, upgrade bouncycastle deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject threatgrid/clj-jwt "0.4.0"
+(defproject threatgrid/clj-jwt "0.5.0-SNAPSHOT"
   :description  "Clojure library for JSON Web Token(JWT)"
   :url          "https://github.com/threatgrid/clj-jwt"
   :pedantic?    :abort

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
                  :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/data.codec "0.1.1"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.52"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.68"]
                  [crypto-equality "1.0.0"]
                  [clj-time "0.15.2"]
                  [metosin/jsonista "0.2.6"]]

--- a/src/clj_jwt/bouncy_castle_provider.clj
+++ b/src/clj_jwt/bouncy_castle_provider.clj
@@ -1,0 +1,6 @@
+(ns clj-jwt.bouncy-castle-provider
+  (:import java.security.Security
+           org.bouncycastle.jce.provider.BouncyCastleProvider))
+
+(defonce __install__
+  (Security/addProvider (BouncyCastleProvider.)))

--- a/src/clj_jwt/bouncy_castle_provider.clj
+++ b/src/clj_jwt/bouncy_castle_provider.clj
@@ -1,4 +1,6 @@
 (ns clj-jwt.bouncy-castle-provider
+  "Same trick used by pandect;
+  see https://github.com/xsc/pandect/blob/main/src/pandect/utils/bouncy_castle_provider.clj"
   (:import java.security.Security
            org.bouncycastle.jce.provider.BouncyCastleProvider))
 

--- a/src/clj_jwt/key.clj
+++ b/src/clj_jwt/key.clj
@@ -9,6 +9,9 @@
     [org.bouncycastle.cert X509CertificateHolder]
     [java.io StringReader]))
 
+;; Mandatory to initialize bouncy castle provider
+(require 'clj-jwt.bouncy-castle-provider)
+
 (defprotocol GetPrivateKey
   (-get-private-key [key-info password]))
 


### PR DESCRIPTION
Fix an issue related to initialization:

Should fix this error message in dependencies depending on how BC is initialized (typically play badly with pandect)

> Exception in thread "main" org.bouncycastle.openssl.PEMException: Unable to create OpenSSL PBDKF: PBKDF-OpenSSL SecretKeyFactory not available

Related to https://github.com/advthreat/iroh/pull/5998