### PR TITLE
Replace joda-time->intdate with ensure-intdate

### DIFF
--- a/src/clj_jwt/core.clj
+++ b/src/clj_jwt/core.clj
@@ -2,7 +2,7 @@
   (:require
     [clj-jwt.base64      :refer [url-safe-encode-str url-safe-decode-str]]
     [clj-jwt.sign        :refer [get-signature-fn get-verify-fn supported-algorithm?]]
-    [clj-jwt.intdate     :refer [joda-time->intdate]]
+    [clj-jwt.intdate     :refer [ensure-intdate]]
     [clj-jwt.json-key-fn :refer [write-key read-key]]
     [clojure.string      :as str]
     [jsonista.core       :as jsonista]))
@@ -39,7 +39,7 @@
 (extend-protocol JsonWebToken
   JWT
   (init [this claims]
-    (let [claims (reduce #(update-map % %2 joda-time->intdate) claims [:exp :nbf :iat])]
+    (let [claims (reduce #(update-map % %2 ensure-intdate) claims [:exp :nbf :iat])]
       (assoc this :header {:alg "none" :typ "JWT"} :claims claims :signature "")))
 
   (encoded-header [this]

--- a/src/clj_jwt/intdate.clj
+++ b/src/clj_jwt/intdate.clj
@@ -2,7 +2,12 @@
   (:require
     [clj-time.coerce :refer [to-long from-long]]))
 
+
+
 (defn- joda-time? [x] (= org.joda.time.DateTime (type x)))
+
+
+
 
 (defn joda-time->intdate
   [d]
@@ -14,3 +19,11 @@
   [i]
   {:pre [(integer? i) (pos? i)]}
   (from-long (* i 1000)))
+
+
+(defn ensure-intdate [x]
+  (cond
+    (int? x)
+    x
+    (joda-time? x)
+    (joda-time->intdate x)))

--- a/test/clj_jwt/intdate_test.clj
+++ b/test/clj_jwt/intdate_test.clj
@@ -15,3 +15,9 @@
     (intdate->joda-time i)   => d
     (intdate->joda-time nil) => (throws AssertionError)))
 
+
+(fact "ensure->intdate should work fine."
+  (let [d (date-time 2000 1 2 3 4 5)]
+    (ensure-intdate d)   => 946782245
+    (ensure-intdate 946782245) => 946782245))
+


### PR DESCRIPTION
If the iat,exp,nbf claims are already integers, don't try to convert them to epoch seconds